### PR TITLE
change bg color of number tile to match empty tiles

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -261,7 +261,16 @@ impl Field {
                         Content::Number(n) => {
                             let transform = context.transform.trans((field_rect[0] + i*cell_w) as f64 + 5.0,
                                                                     (field_rect[1] + (j+1)*cell_h) as f64 - 5.0);
-                            text::Text::colored([1.0, 1.0, 1.0, 1.0], cell_h).draw(
+                            rectangle([1.0, 1.0, 1.0, 1.0],
+                                      [
+                                        (field_rect[0] + i*cell_w) as f64,
+                                        (field_rect[1] + j*cell_h) as f64,
+                                        cell_w as f64,
+                                        cell_h as f64
+                                      ],
+                                      context.transform,
+                                      graphics);
+                            text::Text::colored([0.3, 0.3, 0.3, 1.0], cell_h).draw(
                                 &*n.to_string(),
                                 glyps,
                                 &context.draw_state,


### PR DESCRIPTION
in the original game all the revealed tiles share a background color.
![original minesweeper board](http://i.imgur.com/iHvtWzV.png)

I have changed the background of numbered cells to white.
