### PR TITLE
feat: when you click on a revealed number

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -7,13 +7,13 @@ use piston_window::*;
 pub enum Content {
     Number(u8),
     Mine,
-    None
+    None,
 }
 
 struct Cell {
     content: Content,
     revealed: bool,
-    marked: bool
+    marked: bool,
 }
 
 impl Cell {
@@ -178,6 +178,10 @@ impl Field {
         self.height
     }
 
+    pub fn get_size(&self) -> u32 {
+        self.size
+    }
+
     pub fn restart(&mut self) {
         self.fill();
     } 
@@ -245,6 +249,17 @@ impl Field {
         for i in 0..self.get_width() {
             for j in 0..self.get_height() {
                 let ind = i + j*self.get_width();
+                let transform = context.transform.trans((field_rect[0] + i*cell_w) as f64 + 5.0,
+                                                        (field_rect[1] + (j+1)*cell_h) as f64 - 5.0);
+                /*// show cell numbers, todo: make this a command line option
+                text::Text::colored([1.0, 1.0, 0.0, 1.0], cell_h/2 ).draw(
+                    &*ind.to_string(),
+                    glyps,
+                    &context.draw_state,
+                    transform,
+                    graphics
+                );
+                */
                 if self.revealed(ind) {
                     match *self.get_content(i + j*self.get_width()) {
                         Content::Mine => {
@@ -259,8 +274,6 @@ impl Field {
                                       graphics);
                         },
                         Content::Number(n) => {
-                            let transform = context.transform.trans((field_rect[0] + i*cell_w) as f64 + 5.0,
-                                                                    (field_rect[1] + (j+1)*cell_h) as f64 - 5.0);
                             rectangle([1.0, 1.0, 1.0, 1.0],
                                       [
                                         (field_rect[0] + i*cell_w) as f64,

--- a/src/game.rs
+++ b/src/game.rs
@@ -163,9 +163,34 @@ impl<'a> Game<'a> {
     }
 
     fn open_cell(&mut self, i: u32) {
-        if self.game_ended || (self.field.marked(i)) {
+        if self.game_ended {
             return;
         }
+        
+        if !self.field.revealed(i) {
+            self.check_reveal(i);
+        } else {
+            let on_left_edge = i % self.field.get_width() == 0;
+            let on_right_edge = (i+1) % self.field.get_width() == 0; 
+
+            for rdelta in -1..2i32 {
+                for cdelta in -1..2i32 {
+                    if on_left_edge && cdelta == -1 { continue; }
+                    if on_right_edge && cdelta == 1 { continue; } 
+                    let tgt = (i as i32) + rdelta*(self.field.get_width() as i32) + cdelta;
+                    if tgt < 0 || tgt > self.field.get_size() as i32 { continue; }
+                    self.check_reveal(tgt as u32);
+
+                }
+            }
+        }
+    }
+
+    pub fn check_reveal(&mut self, i : u32) {
+        if self.field.marked(i) {
+            return;
+        }
+
         match *self.field.reveal(i) {
             Content::Mine => {
                 self.field.reveal_all();
@@ -183,7 +208,7 @@ impl<'a> Game<'a> {
                 if self.field.is_victory() {
                     println!("You win :)");
                     self.game_ended = true;
-                }
+                } 
             }
         }
     }


### PR DESCRIPTION
The game "clicks" on unrevealed, unmarked neighbors for you. This makes solving minesweeper puzzles much faster. 

This is a little bit "fast and dirty" but I wanted to get something done and it was neat to actually change the behavior of a game (that there is no way I could have created from scratch). One refactor that I think would be useful would be to add functions to check for a board position on an edge. Maybe adding an enum and a function to field such as `fn on_edge(e: Edge, i : u32) -> bool` and the enum `Edge { Top, Bottom, Left, Right, }`
