### PR TITLE
fix: true number of mines on board, not the case before

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -77,10 +77,26 @@ impl Field {
 
     fn fill(&mut self) {
         self.clear();
-        for _i in 0..self.mines {
-            let ind = rand::thread_rng().gen_range(0, self.size);
-            self.get_cell_mut(ind).content = Content::Mine(false); 
+        //todo: maybe a better algorithm. for now, this
+
+        if self.mines > self.size {
+            panic!("too many mines");// avoid an infinite loop.. could retern a result
         }
+        let mut nmines = 0u32;
+        while nmines < self.mines {
+            let ind = rand::thread_rng().gen_range(0, self.size);
+            let cell = self.get_cell_mut(ind); 
+            match cell.content {
+                Content::Mine(_) => {
+                    continue;
+                },
+                _ => {
+                    cell.content = Content::Mine(false);
+                    nmines += 1;  
+                },
+            }
+        }
+        
         let mut i: i32 = -1;
         let w = self.width as i32;
         while i < (self.size - 1) as i32 {

--- a/src/field.rs
+++ b/src/field.rs
@@ -278,7 +278,7 @@ impl Field {
                             }
                         },
                         Content::Number(n) => {
-                            rectangle([1.0, 1.0, 1.0, 1.0],
+                            rectangle(color::hex("c0c0c0"),
                                       [
                                         (field_rect[0] + i*cell_w) as f64,
                                         (field_rect[1] + j*cell_h) as f64,
@@ -287,7 +287,20 @@ impl Field {
                                       ],
                                       context.transform,
                                       graphics);
-                            text::Text::colored([0.3, 0.3, 0.3, 1.0], cell_h).draw(
+
+                            let text_color = match n {
+                                1 => color::hex("0000ff"),
+                                2 => color::hex("008000"),
+                                3 => color::hex("ff0000"),
+                                4 => color::hex("000080"),
+                                5 => color::hex("800000"),
+                                6 => color::hex("008080"),
+                                7 => color::hex("000000"),
+                                8 => color::hex("808080"),
+                                _ => [0.0, 0.0, 0.0, 1.0]
+                            };
+
+                            text::Text::colored(text_color, cell_h).draw(
                                 &*n.to_string(),
                                 glyps,
                                 &context.draw_state,
@@ -296,7 +309,7 @@ impl Field {
                             );
                         },
                         Content::None => {
-                            rectangle([1.0, 1.0, 1.0, 1.0],
+                            rectangle(color::hex("c0c0c0"),
                                       [
                                         (field_rect[0] + i*cell_w) as f64,
                                         (field_rect[1] + j*cell_h) as f64,
@@ -307,6 +320,17 @@ impl Field {
                                       graphics);
                         }
                     }
+                } else {
+                    // non revealed
+                    rectangle(color::hex("303030"),
+                              [
+                                (field_rect[0] + i*cell_w) as f64,
+                                (field_rect[1] + j*cell_h) as f64,
+                                cell_w as f64,
+                                cell_h as f64
+                              ],
+                              context.transform,
+                              graphics);
                 }
                 if self.marked(ind) {
                     rectangle([0.0, 1.0, 0.0, 0.75],

--- a/src/field.rs
+++ b/src/field.rs
@@ -77,25 +77,13 @@ impl Field {
 
     fn fill(&mut self) {
         self.clear();
-        //todo: maybe a better algorithm. for now, this
-
-        if self.mines > self.size {
-            panic!("too many mines");// avoid an infinite loop.. could retern a result
-        }
-        let mut nmines = 0u32;
-        while nmines < self.mines {
-            let ind = rand::thread_rng().gen_range(0, self.size);
-            let cell = self.get_cell_mut(ind); 
-            match cell.content {
-                Content::Mine(_) => {
-                    continue;
-                },
-                _ => {
-                    cell.content = Content::Mine(false);
-                    nmines += 1;  
-                },
-            }
-        }
+        let mut rng = rand::thread_rng(); 
+        let mut shuffled_idx : Vec<u32> = (0..self.size).collect();
+        rng.shuffle(&mut shuffled_idx);
+        let _: Vec<&u32>  = shuffled_idx.iter()
+            .take(self.mines as usize)
+            .inspect(|&idx| self.get_cell_mut(*idx).content = Content::Mine(false))
+            .collect(); // collect is required due to lazy eval (i think).
         
         let mut i: i32 = -1;
         let w = self.width as i32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,8 +85,8 @@ fn main() {
                     None => Ok(())
                 }
             }))
-        .arg(Arg::from_usage("-m, --mines [mines] 'max mines'")
-            .min_values(1))
+        .arg(Arg::from_usage("-m, --mines [mines] 'max mines'"))
+        .arg(Arg::from_usage("--oldOGL 'set OpenGL version to 2.1'"))
         .get_matches();
 
     let mut width = 1024;
@@ -94,6 +94,7 @@ fn main() {
     let mut f_width = 20;
     let mut f_height = 20;
     let mut mines = 50;
+    let mut opengl = OpenGL::V3_2;
     if let Some(size) = matches.value_of("size") {
         let mut s = size.split("x");
         width = s.next().unwrap().parse().unwrap_or(width);
@@ -107,10 +108,13 @@ fn main() {
     if let Some(m) = matches.value_of("mines") {
         mines = m.parse().unwrap_or(mines);
     }
+    if letmatches.is_present("oldOGL") {
+        opengl = OpenGL::V2_1;
+    }
 
     let window: PistonWindow =
         WindowSettings::new("Minesweeper", [width, height])
-        .opengl(OpenGL::V2_1)
+        .opengl(opengl)
         .exit_on_esc(true)
         .build()
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
     if let Some(m) = matches.value_of("mines") {
         mines = m.parse().unwrap_or(mines);
     }
-    if letmatches.is_present("oldOGL") {
+    if matches.is_present("oldOGL") {
         opengl = OpenGL::V2_1;
     }
 


### PR DESCRIPTION
If there was a high mine density before, there would not be that many mines on the board. This addresses this issue. I don't know how "fix" suits this commit but that is what I labeled it. 
