### PR TITLE
fix(game): went out of bounds in some cases during neighbor check

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -182,7 +182,7 @@ impl<'a> Game<'a> {
                         continue;
                     }
                     let tgt = (i as i32) + rdelta*(self.field.get_width() as i32) + cdelta;
-                    if (tgt < 0) || (tgt > self.field.get_size() as i32) {
+                    if (tgt < 0) || (tgt >= self.field.get_size() as i32) {
                         continue;
                     }
                     self.check_reveal(tgt as u32);


### PR DESCRIPTION
I introduced a simple off-by-one bug which caused a panic in some cases. Fixed it here.
