### PR TITLE
Add nighty to allowed_failures again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rust:
   - beta
   - stable
 
-#matrix:
-#  allow_failures:
-#    - rust: nightly
+matrix:
+ allow_failures:
+   - rust: nightly


### PR DESCRIPTION
because of `gfx` failure
