### PR TITLE
Implement redrawing when it needs for fixing #22.

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -135,9 +135,9 @@ impl<'a> Game<'a> {
                         Key::H => {
                             match self.ui.proc_key(ParamType::Height) {
                                 Some(h) => {
-                                    self.in_ui = false;
-                                    self.msg.hide();
+                                    self.in_ui = false;                                    
                                     self.field.reinit_field(h, ParamType::Height);
+                                    self.restart();
                                 }
                                 _ => need_redraw = false
                             }
@@ -146,8 +146,8 @@ impl<'a> Game<'a> {
                             match self.ui.proc_key(ParamType::Mines) {
                                 Some(m) => {
                                     self.in_ui = false;
-                                    self.msg.hide();
                                     self.field.reinit_field(m, ParamType::Mines);
+                                    self.restart();
                                 }
                                 _ => need_redraw = false
                             }
@@ -156,8 +156,8 @@ impl<'a> Game<'a> {
                             match self.ui.proc_key(ParamType::Width) {
                                 Some(w) => {
                                     self.in_ui = false;
-                                    self.msg.hide();
                                     self.field.reinit_field(w, ParamType::Width);
+                                    self.restart();
                                 }
                                 _ => need_redraw = false
                             }

--- a/src/game.rs
+++ b/src/game.rs
@@ -346,6 +346,10 @@ impl<'a> Game<'a> {
         }
     }
 
+    pub fn resize(&mut self) {
+        self.render_state.reset();
+    }
+
     fn restart(&mut self) {
         self.game_ended = false;
         self.msg.hide();

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,10 @@ fn main() {
         	game.render(&e);
         }
 
+        if let Some(_) = e.resize_args() {
+        	game.resize()
+        }
+
         if let Some(mouse_rel) = e.mouse_cursor_args() {
             game.mouse_move(mouse_rel);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,11 @@ fn main() {
     let mut game = game::Game::new(glyphs, f_width, f_height, mines);
     window.set_max_fps(max_fps);
     for e in window {
-        game.render(&e);
+        game.update_state();
+
+        if let Some(_) = e.render_args() {
+        	game.render(&e);
+        }
 
         if let Some(mouse_rel) = e.mouse_cursor_args() {
             game.mouse_move(mouse_rel);
@@ -143,5 +147,6 @@ fn main() {
         if let Some(button) = e.press_args() {
             game.proc_key(button, &e);
         }
+
     }
 }


### PR DESCRIPTION
Piston use double buffering for drawing in 2d mode.
RenderState is used for redrawing both buffer when it needs.

On my computer, CPU load dropped from 6-7% percents to 0.3% without any input with default settings.

In general, it works fine, but there are some case that needed addition handling: window resizing, stoping timer after changing field size or mine count and may be something else.
