### PR TITLE
style(all): rustfmt in root, perhaps use a config to tweak settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,21 +1,12 @@
 [root]
 name = "minesweeper"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
- "chrono 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "find_folder 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston_window 0.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "advapi32-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -25,7 +16,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ansi_term"
-version = "0.7.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -34,26 +25,36 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cgl"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gleam 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.2.17"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -61,20 +62,20 @@ name = "clap"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cocoa"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -85,42 +86,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "core-foundation"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "core-graphics"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam"
-version = "0.1.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dlib"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libloading 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -132,11 +143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "dwmapi-sys"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -145,7 +161,7 @@ name = "dylib"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -153,7 +169,7 @@ name = "enum_primitive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -163,21 +179,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "flate2"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "freetype-rs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -185,26 +201,32 @@ name = "freetype-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libz-sys 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fs2"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gcc"
-version = "0.3.21"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "gdi32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,8 +236,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "draw_state 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -225,8 +247,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gfx 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_gl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -237,7 +259,7 @@ dependencies = [
  "gl_common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -272,7 +294,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -282,70 +304,78 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "gleam"
-version = "0.2.0"
+name = "gl_generator"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gl_generator 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gleam"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gl_generator 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "glob"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "glutin"
-version = "0.4.5"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cgl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cocoa 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-graphics 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwmapi-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "khronos_api 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "shared_library 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-kbd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-window 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-kbd 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-window 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "x11-dl 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "image"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum_primitive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gif 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "png 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "png 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "inflate"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -354,11 +384,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "itoa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "kernel32-sys"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -374,7 +409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.1.15"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -384,36 +424,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.4"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libloading"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target_build_utils 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.0.0"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lzw"
@@ -425,7 +463,18 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memmap"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fs2 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -433,34 +482,82 @@ name = "miniz-sys"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "mmap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num"
-version = "0.1.29"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-complex 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-rational 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "num-bigint"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-bigint 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "objc"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -469,8 +566,8 @@ name = "osmesa-sys"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "shared_library 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -479,7 +576,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pistoncore-event_loop 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-input 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pistoncore-window 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -494,7 +591,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gfx 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "image 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "image 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-texture 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -521,7 +618,7 @@ name = "piston2d-gfx_graphics"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "freetype-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "freetype-rs 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-gfx_texture 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-shaders_graphics2d 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -561,9 +658,9 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "piston-viewport 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-input 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pistoncore-window 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -572,20 +669,20 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "pistoncore-input 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pistoncore-window 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pistoncore-input"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston-viewport 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,35 +690,33 @@ name = "pistoncore-window"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "pistoncore-input 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pistoncore-input 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shader_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "png"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "inflate 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -631,15 +726,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.16"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc_version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.6.7"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_json"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -649,11 +770,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "shared_library"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -661,42 +782,43 @@ name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "tempdir"
-version = "0.3.4"
+name = "target_build_utils"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tempfile"
-version = "1.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -704,7 +826,7 @@ name = "user32-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -723,60 +845,59 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.5.6"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "dlib 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-kbd"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "dlib 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "mmap 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memmap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.5.6"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "xml-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.5.5"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "dlib 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dlib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-window"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.5.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -786,11 +907,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "x11-dl"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dylib 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -798,7 +919,7 @@ name = "xml-rs"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -807,5 +928,13 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,17 +2,17 @@
 pub enum ParamType {
     Width,
     Height,
-    Mines
+    Mines,
 }
 
 pub enum MoveDestination {
     Up,
     Down,
     Left,
-    Right
+    Right,
 }
 
 pub enum GameEndState {
     Win,
-    Lose
+    Lose,
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -21,7 +21,7 @@ impl Cell {
         Cell {
             content: Content::None,
             revealed: false,
-            marked: false
+            marked: false,
         }
     }
 
@@ -29,15 +29,15 @@ impl Cell {
         Cell {
             content: Content::Mine(false),
             revealed: false,
-            marked: false
-        }   
+            marked: false,
+        }
     }
 
     pub fn clear(&mut self) {
         self.content = Content::None;
         self.revealed = false;
         self.marked = false;
-    }   
+    }
 
     fn reveal(&mut self) -> &Content {
         self.revealed = true;
@@ -59,7 +59,7 @@ pub struct Field {
     selected_y: u32,
     nubmers_total: u32,
     nubmers_opened: u32,
-    need_regen: bool
+    need_regen: bool,
 }
 
 impl Field {
@@ -69,9 +69,9 @@ impl Field {
             height: height,
             cells: vec![],
             mines: mines,
-            size: width*height,
-            selected_x: width/2,
-            selected_y: height/2,
+            size: width * height,
+            selected_x: width / 2,
+            selected_y: height / 2,
             nubmers_total: 0,
             nubmers_opened: 0,
             need_regen: true,
@@ -87,15 +87,15 @@ impl Field {
 
     fn reinit_vec(&mut self) {
         self.cells.clear();
-        self.size = self.width*self.height;
+        self.size = self.width * self.height;
         for _i in 0..self.size {
             self.cells.push(Cell::create_empty());
         }
-        self.selected_x = self.width/2;
-        self.selected_y = self.height/2;
+        self.selected_x = self.width / 2;
+        self.selected_y = self.height / 2;
     }
 
-    fn reset(&mut self, cursor_ind:u32) {
+    fn reset(&mut self, cursor_ind: u32) {
         self.clear();
 
         let cursor_near_cells = self.get_near_cells_ids(cursor_ind);
@@ -105,7 +105,7 @@ impl Field {
         for i in 0..self.size - cursor_near_cells.len() as u32 {
             let cell = if i < self.mines {
                 Cell::create_with_mine()
-            } else { 
+            } else {
                 Cell::create_empty()
             };
 
@@ -113,7 +113,7 @@ impl Field {
         }
 
         // shuffle them
-        let mut rng = rand::thread_rng(); 
+        let mut rng = rand::thread_rng();
         rng.shuffle(&mut new_cells);
 
         // push empty cells near with cursor to avoid mines in this positions
@@ -127,12 +127,12 @@ impl Field {
         self.need_regen = false;
     }
 
-    fn get_near_cells_ids(&mut self, ind:u32) -> Vec<u32> {
+    fn get_near_cells_ids(&mut self, ind: u32) -> Vec<u32> {
         let (begin_x, end_x, begin_y, end_y) = self.get_3x3_bounds(ind);
-        
+
         let mut cursor_neighbor_cells = Vec::new();
-        for yi in begin_y .. end_y + 1 {
-            for xi in begin_x .. end_x + 1 {
+        for yi in begin_y..end_y + 1 {
+            for xi in begin_x..end_x + 1 {
                 let ind = self.get_cell_index(xi, yi);
                 cursor_neighbor_cells.push(ind);
             }
@@ -151,27 +151,29 @@ impl Field {
                     let ct_mine = |b| {
                         match b {
                             true => 1,
-                            false => 0
+                            false => 0,
                         }
                     };
-                     // don`t care about row
-                    let mut ct = ct_mine(self.is_mine_safe(i-w)) +
-                                 ct_mine(self.is_mine_safe(i+w));
-                    if i % w > 0 { // check left side position
-                        ct += ct_mine(self.is_mine_safe(i-w-1)) +
-                              ct_mine(self.is_mine_safe(i-1)) +
-                              ct_mine(self.is_mine_safe(i+w-1));
+                    // don`t care about row
+                    let mut ct = ct_mine(self.is_mine_safe(i - w)) +
+                                 ct_mine(self.is_mine_safe(i + w));
+                    if i % w > 0 {
+                        // check left side position
+                        ct += ct_mine(self.is_mine_safe(i - w - 1)) +
+                              ct_mine(self.is_mine_safe(i - 1)) +
+                              ct_mine(self.is_mine_safe(i + w - 1));
                     }
-                    if i % w < w - 1 { // check right side position
-                        ct += ct_mine(self.is_mine_safe(i-w+1)) +
-                              ct_mine(self.is_mine_safe(i+1)) +
-                              ct_mine(self.is_mine_safe(i+w+1));
+                    if i % w < w - 1 {
+                        // check right side position
+                        ct += ct_mine(self.is_mine_safe(i - w + 1)) +
+                              ct_mine(self.is_mine_safe(i + 1)) +
+                              ct_mine(self.is_mine_safe(i + w + 1));
                     }
                     if ct > 0 {
                         self.get_cell_mut(i as u32).content = Content::Number(ct);
                         self.nubmers_total += 1;
                     }
-                },
+                }
                 _ => {}
             }
         }
@@ -182,7 +184,7 @@ impl Field {
     }
 
     // return coordinates of cell (x, y) by index in field
-    pub fn get_coord(&mut self, ind: u32) -> (u32, u32){
+    pub fn get_coord(&mut self, ind: u32) -> (u32, u32) {
         (ind % self.width, ind / self.width)
     }
 
@@ -190,8 +192,8 @@ impl Field {
         let (begin_x, end_x, begin_y, end_y) = self.get_3x3_bounds(ind);
 
         let mut marked_count = 0u8;
-        for yi in begin_y .. end_y + 1 {
-            for xi in begin_x .. end_x + 1 {
+        for yi in begin_y..end_y + 1 {
+            for xi in begin_x..end_x + 1 {
                 let ind = self.get_cell_index(xi, yi);
                 if self.marked(ind) {
                     marked_count += 1;
@@ -205,11 +207,27 @@ impl Field {
     // return (begin_x, end_x, begin_y, end_y) for specified position in field
     fn get_3x3_bounds(&mut self, ind: u32) -> (u32, u32, u32, u32) {
         let (x, y) = self.get_coord(ind);
-        
-        let begin_x = if x > 0 { x - 1 } else { x };
-        let end_x = if x + 1 < self.width { x + 1 } else { x };
-        let begin_y = if y > 0 { y - 1 } else { y };
-        let end_y = if y + 1 < self.height { y + 1 } else { y };
+
+        let begin_x = if x > 0 {
+            x - 1
+        } else {
+            x
+        };
+        let end_x = if x + 1 < self.width {
+            x + 1
+        } else {
+            x
+        };
+        let begin_y = if y > 0 {
+            y - 1
+        } else {
+            y
+        };
+        let end_y = if y + 1 < self.height {
+            y + 1
+        } else {
+            y
+        };
 
         (begin_x, end_x, begin_y, end_y)
     }
@@ -240,20 +258,22 @@ impl Field {
     }
 
     pub fn set_killer(&mut self, i: u32) {
-        self.get_cell_mut(i).content = Content::Mine(true); 
+        self.get_cell_mut(i).content = Content::Mine(true);
     }
 
-    fn get_cell_mut(&mut self, i:u32) -> &mut Cell {
-        self.cells.get_mut(i as usize)
+    fn get_cell_mut(&mut self, i: u32) -> &mut Cell {
+        self.cells
+            .get_mut(i as usize)
             .unwrap_or_else(|| panic!("Range check error at Field::get_cell_mut ({})", i))
     }
 
-    fn get_cell(& self, i:u32) -> &Cell {
-        self.cells.get(i as usize)
+    fn get_cell(&self, i: u32) -> &Cell {
+        self.cells
+            .get(i as usize)
             .unwrap_or_else(|| panic!("Range check error at Field::get_cell ({})", i))
     }
 
-    fn get_content_safe(&self, i:i32) -> Option<&Content> {
+    fn get_content_safe(&self, i: i32) -> Option<&Content> {
         if (i < 0) || ((i as u32) >= self.size) {
             None
         } else {
@@ -261,25 +281,24 @@ impl Field {
         }
     }
 
-    pub fn get_content(& self, i: u32) -> &Content {
+    pub fn get_content(&self, i: u32) -> &Content {
         &self.get_cell(i).content
     }
 
     pub fn count_marked(&self) -> u32 {
-        (0..self.size)
-            .fold(0, |acc, i:u32| {
-                if self.marked(i) {
-                    acc + 1
-                } else {
-                    acc
-                }
-            })
+        (0..self.size).fold(0, |acc, i: u32| {
+            if self.marked(i) {
+                acc + 1
+            } else {
+                acc
+            }
+        })
     }
 
     fn is_mine_safe(&self, i: i32) -> bool {
         match self.get_content_safe(i) {
             Some(&Content::Mine(_)) => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -295,16 +314,16 @@ impl Field {
         self.size
     }
 
-    pub fn reset_if_need(&mut self, cursor_ind:u32) {
+    pub fn reset_if_need(&mut self, cursor_ind: u32) {
         if self.need_regen {
             self.reset(cursor_ind);
         }
-    } 
+    }
 
     pub fn reveal_all(&mut self) {
         for i in 0..self.size {
             self.get_cell_mut(i).revealed = true;
-        }  
+        }
     }
 
     pub fn chain_reveal(&mut self, u: u32) {
@@ -321,13 +340,13 @@ impl Field {
                         self.get_cell_mut(x as u32).marked = false;
                         self.reveal(x as u32);
                     }
-                },
+                }
                 Some(&Content::Number(_n)) => {
                     if !(self.revealed(x as u32)) {
                         self.get_cell_mut(x as u32).marked = false;
                         self.reveal(x as u32);
                     }
-                },
+                }
                 _ => {}
             }
         };
@@ -338,44 +357,44 @@ impl Field {
         while !deq.is_empty() {
             let i = deq.pop_front().unwrap();
             // don`t care about row
-            check(i-w, deq);
-            check(i+w, deq);
-            if i % w > 0 { // check left side position
-                check(i-w-1, deq);
-                check(i-1, deq);
-                check(i+w-1, deq);
+            check(i - w, deq);
+            check(i + w, deq);
+            if i % w > 0 {
+                // check left side position
+                check(i - w - 1, deq);
+                check(i - 1, deq);
+                check(i + w - 1, deq);
             }
-            if i % w < w - 1 { // check right side position
-                check(i-w+1, deq);
-                check(i+1, deq);
-                check(i+w+1, deq);
+            if i % w < w - 1 {
+                // check right side position
+                check(i - w + 1, deq);
+                check(i + 1, deq);
+                check(i + w + 1, deq);
             }
         }
     }
 
     pub fn draw(&mut self,
-            context: Context,
-            graphics: &mut G2d,
-            field_rect: [u32; 4],
-            glyps: &mut Glyphs)
-    {
+                context: Context,
+                graphics: &mut G2d,
+                field_rect: [u32; 4],
+                glyps: &mut Glyphs) {
         let cell_w = field_rect[2] / self.get_width();
         let cell_h = field_rect[3] / self.get_height();
         for i in 0..self.get_width() {
             for j in 0..self.get_height() {
-                let ind = i + j*self.get_width();
-                let transform = context.transform.trans((field_rect[0] + i*cell_w) as f64 + 5.0,
-                                                        (field_rect[1] + (j+1)*cell_h) as f64 - 5.0);
+                let ind = i + j * self.get_width();
+                let transform = context.transform.trans((field_rect[0] + i * cell_w) as f64 + 5.0,
+                                                        (field_rect[1] + (j + 1) * cell_h) as f64 -
+                                                        5.0);
                 if self.revealed(ind) {
-                    match *self.get_content(i + j*self.get_width()) {
+                    match *self.get_content(i + j * self.get_width()) {
                         Content::Mine(killer) => {
                             rectangle([1.0, 0.0, 0.0, 1.0],
-                                      [
-                                        (field_rect[0] + i*cell_w) as f64,
-                                        (field_rect[1] + j*cell_h) as f64,
-                                        cell_w as f64,
-                                        cell_h as f64
-                                      ],
+                                      [(field_rect[0] + i * cell_w) as f64,
+                                       (field_rect[1] + j * cell_h) as f64,
+                                       cell_w as f64,
+                                       cell_h as f64],
                                       context.transform,
                                       graphics);
                             if killer {
@@ -386,15 +405,13 @@ impl Field {
                                      transform,
                                      graphics);
                             }
-                        },
+                        }
                         Content::Number(n) => {
                             rectangle(color::hex("c0c0c0"),
-                                      [
-                                        (field_rect[0] + i*cell_w) as f64,
-                                        (field_rect[1] + j*cell_h) as f64,
-                                        cell_w as f64,
-                                        cell_h as f64
-                                      ],
+                                      [(field_rect[0] + i * cell_w) as f64,
+                                       (field_rect[1] + j * cell_h) as f64,
+                                       cell_w as f64,
+                                       cell_h as f64],
                                       context.transform,
                                       graphics);
 
@@ -407,7 +424,7 @@ impl Field {
                                 6 => color::hex("008080"),
                                 7 => color::hex("000000"),
                                 8 => color::hex("808080"),
-                                _ => [0.0, 0.0, 0.0, 1.0]
+                                _ => [0.0, 0.0, 0.0, 1.0],
                             };
                             text(text_color,
                                  cell_h,
@@ -415,15 +432,13 @@ impl Field {
                                  glyps,
                                  transform,
                                  graphics);
-                        },
+                        }
                         Content::None => {
                             rectangle(color::hex("c0c0c0"),
-                                      [
-                                        (field_rect[0] + i*cell_w) as f64,
-                                        (field_rect[1] + j*cell_h) as f64,
-                                        cell_w as f64,
-                                        cell_h as f64
-                                      ],
+                                      [(field_rect[0] + i * cell_w) as f64,
+                                       (field_rect[1] + j * cell_h) as f64,
+                                       cell_w as f64,
+                                       cell_h as f64],
                                       context.transform,
                                       graphics);
                         }
@@ -431,58 +446,48 @@ impl Field {
                 } else {
                     // non revealed
                     rectangle(color::hex("303030"),
-                              [
-                                (field_rect[0] + i*cell_w) as f64,
-                                (field_rect[1] + j*cell_h) as f64,
-                                cell_w as f64,
-                                cell_h as f64
-                              ],
+                              [(field_rect[0] + i * cell_w) as f64,
+                               (field_rect[1] + j * cell_h) as f64,
+                               cell_w as f64,
+                               cell_h as f64],
                               context.transform,
                               graphics);
                 }
                 if self.marked(ind) {
                     rectangle([0.0, 1.0, 0.0, 0.75],
-                              [
-                                (field_rect[0] + i*cell_w) as f64,
-                                (field_rect[1] + j*cell_h) as f64,
-                                cell_w as f64,
-                                cell_h as f64
-                              ],
+                              [(field_rect[0] + i * cell_w) as f64,
+                               (field_rect[1] + j * cell_h) as f64,
+                               cell_w as f64,
+                               cell_h as f64],
                               context.transform,
                               graphics);
                 }
             }
         }
         rectangle([0.5, 0.5, 0.5, 0.75],
-                  [
-                    (field_rect[0] + self.selected_x*cell_w) as f64,
-                    (field_rect[1] + self.selected_y*cell_h) as f64,
-                    cell_w as f64,
-                    cell_h as f64
-                  ],
+                  [(field_rect[0] + self.selected_x * cell_w) as f64,
+                   (field_rect[1] + self.selected_y * cell_h) as f64,
+                   cell_w as f64,
+                   cell_h as f64],
                   context.transform,
                   graphics);
         for i in 0..self.get_width() + 1 {
             line([0.5, 0.5, 0.5, 1.0],
                  1.0,
-                 [
-                    (field_rect[0] + i*cell_w) as f64,
-                    field_rect[1] as f64,
-                    (field_rect[0] + i*cell_w) as f64,
-                    (field_rect[1] + field_rect[3]) as f64
-                 ],
+                 [(field_rect[0] + i * cell_w) as f64,
+                  field_rect[1] as f64,
+                  (field_rect[0] + i * cell_w) as f64,
+                  (field_rect[1] + field_rect[3]) as f64],
                  context.transform,
                  graphics);
         }
         for i in 0..self.get_height() + 1 {
             line([0.5, 0.5, 0.5, 1.0],
                  1.0,
-                 [
-                    field_rect[0] as f64,
-                    (field_rect[1] + i*cell_h) as f64,
-                    (field_rect[0] + field_rect[2]) as f64,
-                    (field_rect[1] + i*cell_h) as f64
-                 ],
+                 [field_rect[0] as f64,
+                  (field_rect[1] + i * cell_h) as f64,
+                  (field_rect[0] + field_rect[2]) as f64,
+                  (field_rect[1] + i * cell_h) as f64],
                  context.transform,
                  graphics);
         }
@@ -494,17 +499,17 @@ impl Field {
                 if self.selected_y > 0 {
                     self.selected_y -= 1;
                 }
-            },
+            }
             MoveDestination::Down => {
                 if self.selected_y < self.height - 1 {
                     self.selected_y += 1;
                 }
-            },
+            }
             MoveDestination::Left => {
                 if self.selected_x > 0 {
                     self.selected_x -= 1;
                 }
-            },
+            }
             MoveDestination::Right => {
                 if self.selected_x < self.width - 1 {
                     self.selected_x += 1;

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,7 +3,7 @@ use ui::UI;
 use ui::EndMessage;
 use piston_window::*;
 use common::{ParamType, MoveDestination, GameEndState};
-use chrono::{DateTime, UTC, Duration};  
+use chrono::{DateTime, UTC, Duration};
 
 enum RenderState {
     // redraw picture on current buffer
@@ -13,17 +13,16 @@ enum RenderState {
     Second,
 
     // needn't redraw picture
-    None
+    None,
 }
 
 impl RenderState {
-
     // Update render state and return flag necessity of redrawing pickture
     fn update_state(&mut self) -> bool {
         match *self {
-            RenderState::First  => *self = RenderState::Second,
+            RenderState::First => *self = RenderState::Second,
             RenderState::Second => *self = RenderState::None,
-            RenderState::None   => return false
+            RenderState::None => return false,
         }
 
         true
@@ -44,11 +43,11 @@ pub struct Game<'a> {
     game_ended: bool,
     panel_width: u32,
     in_ui: bool,
-    game_start : Option<DateTime<UTC>>,
-    last_time : Option<DateTime<UTC>>,
-    game_end : Option<DateTime<UTC>>,
+    game_start: Option<DateTime<UTC>>,
+    last_time: Option<DateTime<UTC>>,
+    game_end: Option<DateTime<UTC>>,
     // state of rendering for drawing picture on both buffers
-    render_state: RenderState
+    render_state: RenderState,
 }
 
 impl<'a> Game<'a> {
@@ -66,11 +65,11 @@ impl<'a> Game<'a> {
             game_start: None,
             game_end: None,
             last_time: None,
-            render_state: RenderState::First
+            render_state: RenderState::First,
         }
     }
 
-    pub fn render(&mut self, window: &PistonWindow) {      
+    pub fn render(&mut self, window: &PistonWindow) {
         if !self.render_state.update_state() {
             return;
         }
@@ -83,14 +82,22 @@ impl<'a> Game<'a> {
             let ui_rect = self.get_ui_rect(window);
 
             let dur = match self.game_start {
-                Some(game_start) => match self.game_end {
-                    Some(game_end) => game_end - game_start,
-                    None => UTC::now() - game_start,
-                },
+                Some(game_start) => {
+                    match self.game_end {
+                        Some(game_end) => game_end - game_start,
+                        None => UTC::now() - game_start,
+                    }
+                }
                 None => Duration::seconds(0), 
             };
 
-            self.ui.draw(c, g, ui_rect, &mut self.glyphs, self.field.total_mines(), self.field.count_marked(), dur);
+            self.ui.draw(c,
+                         g,
+                         ui_rect,
+                         &mut self.glyphs,
+                         self.field.total_mines(),
+                         self.field.count_marked(),
+                         dur);
 
             let msg_rect = self.get_msg_rect(window);
             self.msg.draw(c, g, msg_rect, &mut self.glyphs);
@@ -99,31 +106,26 @@ impl<'a> Game<'a> {
 
     fn get_field_rect(&self, window: &PistonWindow) -> [u32; 4] {
         let mut w = window.size().width - self.panel_width;
-        w = (w /self.field.get_width()) * self.field.get_width();
+        w = (w / self.field.get_width()) * self.field.get_width();
         let mut h = window.size().height;
-        h = (h /self.field.get_height()) * self.field.get_height();
+        h = (h / self.field.get_height()) * self.field.get_height();
         [0, 0, w, h]
     }
 
     fn get_ui_rect(&self, window: &PistonWindow) -> [u32; 4] {
         let mut field_w = window.size().width - self.panel_width;
-        field_w = (field_w /self.field.get_width()) * self.field.get_width();
+        field_w = (field_w / self.field.get_width()) * self.field.get_width();
         let w = window.size().width - field_w;
         let h = window.size().height;
         [field_w, 0, w, h]
     }
-    
+
     fn get_msg_rect(&self, window: &PistonWindow) -> [u32; 4] {
         let w_w = window.size().width;
         let w_h = window.size().height;
         let (m_w, m_h) = EndMessage::size();
 
-        [
-            ( (w_w-m_w) / 2 ),
-            ( (w_h-m_h) / 2 ),
-            m_w,
-            m_h        
-        ]
+        [((w_w - m_w) / 2), ((w_h - m_h) / 2), m_w, m_h]
     }
 
     pub fn proc_key(&mut self, button: Button, window: &PistonWindow) {
@@ -131,17 +133,17 @@ impl<'a> Game<'a> {
         if self.in_ui {
             match button {
                 Button::Keyboard(key) => {
-                    match  key {
+                    match key {
                         Key::H => {
                             match self.ui.proc_key(ParamType::Height) {
                                 Some(h) => {
-                                    self.in_ui = false;                                    
+                                    self.in_ui = false;
                                     self.field.reinit_field(h, ParamType::Height);
                                     self.restart();
                                 }
-                                _ => need_redraw = false
+                                _ => need_redraw = false,
                             }
-                        },
+                        }
                         Key::M => {
                             match self.ui.proc_key(ParamType::Mines) {
                                 Some(m) => {
@@ -149,9 +151,9 @@ impl<'a> Game<'a> {
                                     self.field.reinit_field(m, ParamType::Mines);
                                     self.restart();
                                 }
-                                _ => need_redraw = false
+                                _ => need_redraw = false,
                             }
-                        },
+                        }
                         Key::W => {
                             match self.ui.proc_key(ParamType::Width) {
                                 Some(w) => {
@@ -159,17 +161,17 @@ impl<'a> Game<'a> {
                                     self.field.reinit_field(w, ParamType::Width);
                                     self.restart();
                                 }
-                                _ => need_redraw = false
+                                _ => need_redraw = false,
                             }
-                        },
+                        }
                         Key::Up => self.ui.change_selected(MoveDestination::Up),
                         Key::Down => self.ui.change_selected(MoveDestination::Down),
                         Key::Left => self.ui.change_selected(MoveDestination::Left),
                         Key::Right => self.ui.change_selected(MoveDestination::Right),
-                        _ => need_redraw = false
+                        _ => need_redraw = false,
                     }
                 }
-                _ => need_redraw = false
+                _ => need_redraw = false,
             }
         } else {
             match button {
@@ -183,7 +185,7 @@ impl<'a> Game<'a> {
                         Key::Space => {
                             let ind = self.field.get_selected_ind();
                             self.open_cell(ind);
-                        },
+                        }
                         Key::LCtrl | Key::RCtrl => {
                             let ind = self.field.get_selected_ind();
                             self.toggle_mark(ind);
@@ -191,18 +193,18 @@ impl<'a> Game<'a> {
                         Key::H => {
                             self.ui.proc_key(ParamType::Height);
                             self.in_ui = true;
-                        },
-                        Key::M =>{
+                        }
+                        Key::M => {
                             self.ui.proc_key(ParamType::Mines);
                             self.in_ui = true;
-                        },
+                        }
                         Key::W => {
                             self.ui.proc_key(ParamType::Width);
                             self.in_ui = true;
-                        },
-                        _ => need_redraw = false
+                        }
+                        _ => need_redraw = false,
                     }
-                },
+                }
                 Button::Mouse(btn) => {
                     let field_rect = self.get_field_rect(window);
                     let cell_w = field_rect[2] / self.field.get_width();
@@ -210,7 +212,8 @@ impl<'a> Game<'a> {
                     let mouse_x = self.mouse_x.floor() as u32;
                     let mouse_y = self.mouse_y.floor() as u32;
                     if (mouse_x < field_rect[0]) || (mouse_x > field_rect[0] + field_rect[2]) ||
-                       (mouse_y < field_rect[1]) || (mouse_y > field_rect[1] + field_rect[3]) {
+                       (mouse_y < field_rect[1]) ||
+                       (mouse_y > field_rect[1] + field_rect[3]) {
                         return;
                     }
                     let x = (mouse_x - field_rect[0]) / cell_w;
@@ -218,13 +221,13 @@ impl<'a> Game<'a> {
                     let w = self.field.get_width();
                     match btn {
                         MouseButton::Left => {
-                            self.open_cell(x + y*w);
-                        },
+                            self.open_cell(x + y * w);
+                        }
                         MouseButton::Right => {
 
-                            self.toggle_mark(x + y*w);
-                        },
-                        _ => need_redraw = false
+                            self.toggle_mark(x + y * w);
+                        }
+                        _ => need_redraw = false,
                     }
                 }
                 Button::Joystick(_) => {
@@ -251,7 +254,7 @@ impl<'a> Game<'a> {
             return;
         }
         if self.game_start == None {
-            self.game_start = Some(UTC::now()); 
+            self.game_start = Some(UTC::now());
         }
 
         self.field.reset_if_need(i);
@@ -275,7 +278,7 @@ impl<'a> Game<'a> {
         if let Some(cells_count) = cells_count_opt {
             if self.field.get_neighborhood_count(i) == cells_count {
                 let on_left_edge = i % self.field.get_width() == 0;
-                let on_right_edge = (i+1) % self.field.get_width() == 0; 
+                let on_right_edge = (i + 1) % self.field.get_width() == 0;
 
                 for rdelta in -1..2i32 {
                     for cdelta in -1..2i32 {
@@ -285,7 +288,7 @@ impl<'a> Game<'a> {
                         if on_right_edge && (cdelta == 1) {
                             continue;
                         }
-                        let tgt = (i as i32) + rdelta*(self.field.get_width() as i32) + cdelta;
+                        let tgt = (i as i32) + rdelta * (self.field.get_width() as i32) + cdelta;
                         if (tgt < 0) || (tgt >= self.field.get_size() as i32) {
                             continue;
                         }
@@ -296,7 +299,7 @@ impl<'a> Game<'a> {
         }
     }
 
-    pub fn check_reveal(&mut self, i : u32) {
+    pub fn check_reveal(&mut self, i: u32) {
         if self.field.marked(i) {
             return;
         }
@@ -305,26 +308,26 @@ impl<'a> Game<'a> {
                 self.field.reveal_all();
                 self.game_ended = true;
                 self.field.set_killer(i);
-                self.game_end = Some(UTC::now()); 
-                self.msg.show( GameEndState::Lose );
+                self.game_end = Some(UTC::now());
+                self.msg.show(GameEndState::Lose);
                 println!("Game over :(");
-            },
+            }
             Content::None => {
                 self.field.chain_reveal(i);
                 if self.field.is_victory() {
-                    self.msg.show( GameEndState::Win );
+                    self.msg.show(GameEndState::Win);
                     println!("You win :)");
                     self.game_ended = true;
-                    self.game_end = Some(UTC::now()); 
+                    self.game_end = Some(UTC::now());
                 }
             }
             Content::Number(_i) => {
                 if self.field.is_victory() {
-                    self.msg.show( GameEndState::Win );
+                    self.msg.show(GameEndState::Win);
                     println!("You win :)");
                     self.game_ended = true;
-                    self.game_end = Some(UTC::now()); 
-                } 
+                    self.game_end = Some(UTC::now());
+                }
             }
         }
     }
@@ -345,7 +348,7 @@ impl<'a> Game<'a> {
                             self.last_time = Some(now);
                             self.render_state.reset();
                         }
-                    },
+                    }
                     None => self.last_time = Some(now),
                 }
             }
@@ -360,7 +363,7 @@ impl<'a> Game<'a> {
         self.game_ended = false;
         self.msg.hide();
         self.game_start = None;
-        self.game_end = None; 
+        self.game_end = None;
         self.last_time = None;
         self.field.restart();
         self.render_state.reset();

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,15 +118,15 @@ fn main() {
         opengl = OpenGL::V2_1;
     }
 
-    let mut window: PistonWindow =
-        WindowSettings::new("Minesweeper", [width, height])
+    let mut window: PistonWindow = WindowSettings::new("Minesweeper", [width, height])
         .opengl(opengl)
         .exit_on_esc(true)
         .build()
         .expect("Try running with --oldOGL");
 
     let assets = find_folder::Search::ParentsThenKids(3, 3)
-        .for_folder("assets").unwrap();
+        .for_folder("assets")
+        .unwrap();
     let ref font = assets.join("FiraSans-Regular.ttf");
     let factory = window.factory.borrow().clone();
     let glyphs = Glyphs::new(font, factory).unwrap();
@@ -137,11 +137,11 @@ fn main() {
         game.update_state();
 
         if let Some(_) = e.render_args() {
-        	game.render(&e);
+            game.render(&e);
         }
 
         if let Some(_) = e.resize_args() {
-        	game.resize()
+            game.resize()
         }
 
         if let Some(mouse_rel) = e.mouse_cursor_args() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,15 +118,15 @@ fn main() {
         opengl = OpenGL::V2_1;
     }
 
-    let mut window: PistonWindow =
-        WindowSettings::new("Minesweeper", [width, height])
+    let mut window: PistonWindow = WindowSettings::new("Minesweeper", [width, height])
         .opengl(opengl)
         .exit_on_esc(true)
         .build()
         .unwrap();
 
     let assets = find_folder::Search::ParentsThenKids(3, 3)
-        .for_folder("assets").unwrap();
+        .for_folder("assets")
+        .unwrap();
     let ref font = assets.join("FiraSans-Regular.ttf");
     let factory = window.factory.borrow().clone();
     let glyphs = Glyphs::new(font, factory).unwrap();
@@ -137,11 +137,11 @@ fn main() {
         game.update_state();
 
         if let Some(_) = e.render_args() {
-        	game.render(&e);
+            game.render(&e);
         }
 
         if let Some(_) = e.resize_args() {
-        	game.resize()
+            game.resize()
         }
 
         if let Some(mouse_rel) = e.mouse_cursor_args() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
         .opengl(opengl)
         .exit_on_esc(true)
         .build()
-        .unwrap();
+        .expect("Try running with --oldOGL");
 
     let assets = find_folder::Search::ParentsThenKids(3, 3)
         .for_folder("assets").unwrap();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,7 +4,7 @@ use common::{ParamType, MoveDestination, GameEndState};
 use chrono::Duration;
 
 struct Block<'a> {
-    name: &'a str, 
+    name: &'a str,
     num: u32,
     old_num: u32,
     hotkey: char,
@@ -20,8 +20,8 @@ impl<'a> Block<'a> {
                hotkey: char,
                min_val: u32,
                max_val: u32,
-               param_type: ParamType) -> Block<'a>
-    {
+               param_type: ParamType)
+               -> Block<'a> {
         Block {
             name: name,
             num: num,
@@ -38,8 +38,7 @@ impl<'a> Block<'a> {
                 context: Context,
                 graphics: &mut G2d,
                 rect: &mut [u32; 4],
-                glyps: &mut Glyphs)
-    {
+                glyps: &mut Glyphs) {
         let margin = 10;
         let text_height = 20;
         let block_height = 30;
@@ -51,12 +50,10 @@ impl<'a> Block<'a> {
         };
         rect[1] += 20;
         rectangle(color,
-                  [
-                    (rect[0] + margin) as f64,
-                    (rect[1]) as f64,
-                    (rect[2] - 2*margin) as f64,
-                    block_height as f64
-                  ],
+                  [(rect[0] + margin) as f64,
+                   (rect[1]) as f64,
+                   (rect[2] - 2 * margin) as f64,
+                   block_height as f64],
                   context.transform,
                   graphics);
         rect[1] += block_height;
@@ -68,9 +65,8 @@ impl<'a> Block<'a> {
              glyps,
              transform,
              graphics);
-        rect[1] += margin + text_height/2;
-        let transform = context.transform.trans((rect[0] + margin) as f64,
-                                                (rect[1]) as f64);
+        rect[1] += margin + text_height / 2;
+        let transform = context.transform.trans((rect[0] + margin) as f64, (rect[1]) as f64);
         let s = if self.selected {
             format!("Use arrows, press '{}' to apply changes", self.hotkey)
         } else {
@@ -108,7 +104,7 @@ impl<'a> Block<'a> {
 pub struct UI<'a> {
     blocks: Vec<Block<'a>>,
     selected_block: i32,
-}    
+}
 
 impl<'a> UI<'a> {
     pub fn new(height: u32, width: u32, mines: u32) -> UI<'a> {
@@ -122,32 +118,31 @@ impl<'a> UI<'a> {
     }
 
     pub fn draw(&mut self,
-            context: Context,
-            graphics: &mut G2d,
-            mut rect: [u32; 4],
-            glyps: &mut Glyphs,
-            mines_total: u32,
-            mines_marked: u32,
-            duration : Duration)
-    {
+                context: Context,
+                graphics: &mut G2d,
+                mut rect: [u32; 4],
+                glyps: &mut Glyphs,
+                mines_total: u32,
+                mines_marked: u32,
+                duration: Duration) {
         for b in self.blocks.iter() {
             b.draw(context, graphics, &mut rect, glyps);
         }
 
-        let transform = context.transform.trans((rect[0]+10) as f64,
-                                                 (rect[1]+27) as f64);
+        let transform = context.transform.trans((rect[0] + 10) as f64, (rect[1] + 27) as f64);
         text([1.0, 1.0, 1.0, 1.0],
              20,
-             &*format!("{} marked {} remaining", mines_marked, mines_total as i32 - mines_marked as i32),
+             &*format!("{} marked {} remaining",
+                       mines_marked,
+                       mines_total as i32 - mines_marked as i32),
              glyps,
              transform,
              graphics);
-        
-        let transform = context.transform.trans((rect[0]+10) as f64,
-                                                 (rect[1]+27*2) as f64);
+
+        let transform = context.transform.trans((rect[0] + 10) as f64, (rect[1] + 27 * 2) as f64);
         let total_seconds = duration.num_seconds();
         let mins = total_seconds / 60;
-        let rem_seconds = total_seconds - mins*60;
+        let rem_seconds = total_seconds - mins * 60;
 
         text([1.0, 1.0, 1.0, 1.0],
              20,
@@ -185,7 +180,7 @@ impl<'a> UI<'a> {
         let selected = self.blocks.get_mut(self.selected_block as usize).unwrap();
         match dest {
             MoveDestination::Up | MoveDestination::Right => selected.inc_safe(),
-            MoveDestination::Down | MoveDestination::Left => selected.dec_safe()
+            MoveDestination::Down | MoveDestination::Left => selected.dec_safe(),
         }
     }
 }
@@ -193,13 +188,13 @@ impl<'a> UI<'a> {
 pub struct EndMessage<'a> {
     visible: bool,
     win: bool,
-    message: &'a str
+    message: &'a str,
 }
 
-static EM_TEXT_BIG      : u32 = 40;
-static EM_TEXT_SMALL    : u32 = 20;
-static EM_TEXT_PADDING  : u32 = 5;
-static EM_BORDER_WIDTH  : u32 = 3;
+static EM_TEXT_BIG: u32 = 40;
+static EM_TEXT_SMALL: u32 = 20;
+static EM_TEXT_PADDING: u32 = 5;
+static EM_BORDER_WIDTH: u32 = 3;
 static EM_BORDER_WIDTH_2: u32 = 6;
 
 static RETRY_MSG: &'static str = "Press 'R' to play again";
@@ -213,38 +208,30 @@ impl<'a> EndMessage<'a> {
         }
     }
 
-    pub fn show( &mut self, end_state: GameEndState ) {
+    pub fn show(&mut self, end_state: GameEndState) {
         self.win = match end_state {
             GameEndState::Win => true,
-            _                 => false };
+            _ => false,
+        };
         self.visible = true;
         self.message = if self.win {
-                "You WIN :)"
-            } else {
-                "Game over :("
-            };
+            "You WIN :)"
+        } else {
+            "Game over :("
+        };
     }
 
-    pub fn hide( &mut self ) {
+    pub fn hide(&mut self) {
         self.visible = false;
     }
 
     /// Message Box's size. (width,height).
-    pub fn size() -> (u32,u32) {
-        (
-            350,
-            (EM_TEXT_BIG + EM_TEXT_SMALL + (EM_TEXT_PADDING*4) + (EM_BORDER_WIDTH*2))
-        )
+    pub fn size() -> (u32, u32) {
+        (350, (EM_TEXT_BIG + EM_TEXT_SMALL + (EM_TEXT_PADDING * 4) + (EM_BORDER_WIDTH * 2)))
     }
 
-    pub fn draw(&self,
-        context: Context,
-        graphics: &mut G2d,
-        rect: [u32; 4],
-        glyps: &mut Glyphs)
-    {
-        if !self.visible
-        {
+    pub fn draw(&self, context: Context, graphics: &mut G2d, rect: [u32; 4], glyps: &mut Glyphs) {
+        if !self.visible {
             return;
         }
 
@@ -256,30 +243,23 @@ impl<'a> EndMessage<'a> {
 
         // draw border
         rectangle(border_color,
-            [
-                (rect[0]) as f64,
-                (rect[1]) as f64,
-                (rect[2]) as f64,
-                (rect[3]) as f64
-            ],
-            context.transform,
-            graphics);
+                  [(rect[0]) as f64, (rect[1]) as f64, (rect[2]) as f64, (rect[3]) as f64],
+                  context.transform,
+                  graphics);
 
         // draw background
-        rectangle( [1.0, 1.0, 1.0, 1.0],
-            [
-                (rect[0] +EM_BORDER_WIDTH) as f64,
-                (rect[1] +EM_BORDER_WIDTH) as f64,
-                (rect[2] -EM_BORDER_WIDTH_2) as f64,
-                (rect[3] -EM_BORDER_WIDTH_2) as f64
-            ],
-            context.transform,
-            graphics);
+        rectangle([1.0, 1.0, 1.0, 1.0],
+                  [(rect[0] + EM_BORDER_WIDTH) as f64,
+                   (rect[1] + EM_BORDER_WIDTH) as f64,
+                   (rect[2] - EM_BORDER_WIDTH_2) as f64,
+                   (rect[3] - EM_BORDER_WIDTH_2) as f64],
+                  context.transform,
+                  graphics);
 
         // Draw game result message
-        let trans_msg = context.transform.trans(
-            (rect[0] + EM_BORDER_WIDTH + EM_TEXT_PADDING) as f64,
-            (rect[1] + EM_BORDER_WIDTH + EM_TEXT_PADDING + EM_TEXT_BIG) as f64);
+        let trans_msg = context.transform
+            .trans((rect[0] + EM_BORDER_WIDTH + EM_TEXT_PADDING) as f64,
+                   (rect[1] + EM_BORDER_WIDTH + EM_TEXT_PADDING + EM_TEXT_BIG) as f64);
 
         text([0.0, 0.0, 0.0, 1.0],
              EM_TEXT_BIG,
@@ -289,9 +269,10 @@ impl<'a> EndMessage<'a> {
              graphics);
 
         // Draw 'play again' message
-        let trans_retry = context.transform.trans(
-            (rect[0] + EM_BORDER_WIDTH + EM_TEXT_PADDING) as f64,
-            (rect[1] + EM_BORDER_WIDTH + EM_TEXT_PADDING*2 + EM_TEXT_BIG + EM_TEXT_SMALL) as f64);
+        let trans_retry = context.transform
+            .trans((rect[0] + EM_BORDER_WIDTH + EM_TEXT_PADDING) as f64,
+                   (rect[1] + EM_BORDER_WIDTH + EM_TEXT_PADDING * 2 + EM_TEXT_BIG +
+                    EM_TEXT_SMALL) as f64);
         text([0.0, 0.0, 0.0, 1.0],
              EM_TEXT_SMALL,
              &*RETRY_MSG,


### PR DESCRIPTION
I was starting to write some code in this project and ran rustfmt on the project to stay with project style settings but realized it had not been done before. This is just a run of `cargo fmt` from the root of the project on current master. If you are against this kind of thing then feel free to close this PR. If you like this kind of thing you may want to consider adding it to travis as in [this](http://johannh.me/blog/rustfmt-ci.html).
